### PR TITLE
Authorization Code flow, refactoring, maintenance import script, configurable import template and automatic token refreshing

### DIFF
--- a/Mendeley.hooks.php
+++ b/Mendeley.hooks.php
@@ -130,7 +130,7 @@ class MendeleyHooks {
 		return $results;
 	}
 
-	public static function httpRequest($url, $post = "", $headers = array()) {
+	public static function httpRequest($url, $post = "", $headers = array(), &$responseHeaders = array() ) {
 		try {
 			$ch = curl_init();
 			//Change the user agent below suitably
@@ -143,6 +143,7 @@ class MendeleyHooks {
 			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
 			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 			curl_setopt($ch, CURLOPT_VERBOSE, 1);
+			curl_setopt($ch, CURLOPT_HEADER, 1);
 
 			if (!empty($post)) {
 				curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
@@ -151,11 +152,14 @@ class MendeleyHooks {
 			if (!empty($headers)) {
 				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 			}
-			$result = curl_exec($ch);
+			$response = curl_exec($ch);
 
-			if (!$result) {
+			if (!$response) {
 				throw new Exception("Error getting data from server: " . curl_error($ch));
 			}
+			$header_size = curl_getinfo( $ch, CURLINFO_HEADER_SIZE );
+			$responseHeaders = explode( "\r\n", substr( $response, 0, $header_size ) );
+			$body = substr( $response, $header_size );
 
 			curl_close($ch);
 		}
@@ -163,7 +167,7 @@ class MendeleyHooks {
 			echo 'Caught exception: ', $e->getMessage(), "\n";
 			return null;
 		}
-		return $result;
+		return $body;
 	}
 
 }

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -180,9 +180,17 @@ class Mendeley {
 	}
 
 	public function getAccessToken() {
-		global $wgMendeleyConsumerKey, $wgMendeleyConsumerSecret, $wgMendeleyToken;
+		global $wgMendeleyConsumerKey, $wgMendeleyConsumerSecret,
+			   $wgMendeleyToken, $wgMemCachedServers, $wgObjectCaches;
+
 		// test against $wgMendeleyToken to ensure we want to use the auth code flow
 		if ( !empty($wgMendeleyToken) ) {
+			if ( !count($wgMemCachedServers) && !isset($wgObjectCaches['redis']) ) {
+				throw new Exception(
+					"The Mendeley extension is configured to use Authorization Code " .
+					"flow but neither Memcached nor Redis cache is found!"
+				);
+			}
 			return $this->getToken( 'access' );
 		}
 		$result = $this->httpRequest( "https://api.mendeley.com/oauth/token", "grant_type=client_credentials&scope=all&client_id=$wgMendeleyConsumerKey&client_secret=$wgMendeleyConsumerSecret" );

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -1,0 +1,288 @@
+<?php
+
+class Mendeley {
+
+	private static $instance;
+
+	public static function getInstance() {
+		if ( self::$instance === null ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Imports a group from Mendeley
+	 *
+	 * @param string $group_id
+	 *
+	 * @return Title[]
+	 * @throws MWContentSerializationException
+	 * @throws MWException
+	 */
+	public function importGroup( $group_id ) {
+		global $wgMendeleyTemplate,
+			   $wgMendeleyTemplateFields,
+			   $wgMendeleyTemplateFieldsMapDelimiter,
+			   $wgMendeleyPageFormula;
+
+		$pages = 0;
+		$pagesLinks = [];
+		$access_token = $this->getAccessToken();
+		$responseHeaders = [];
+		$result = $this->httpRequest(
+			"https://api.mendeley.com/documents" .
+			"?access_token=$access_token" .
+			"&group_id=$group_id" .
+			"&view=all" .
+			"&limit=50",
+			'',
+			array(),
+			$responseHeaders
+		);
+		$result = json_decode( $result, true );
+
+		// Token has expired: oauth/TOKEN_EXPIRED
+		// This is necessary because we don't know initial token issue timestamp
+		if ( isset( $result['errorId'] ) ) {
+			// refresh token
+			wfDebugLog( 'Mendeley', $result['message'] );
+			$this->refreshAccessToken();
+			$access_token = $this->getAccessToken();
+			$responseHeaders = [];
+			$result = $this->httpRequest(
+				"https://api.mendeley.com/documents" .
+				"?access_token=$access_token" .
+				"&group_id=$group_id" .
+				"&view=all" .
+				"&limit=50",
+				'',
+				array(),
+				$responseHeaders
+			);
+			$result = json_decode( $result, true );
+		}
+
+		while ( true ) {
+			foreach ( $result as $result_row ) {
+
+				$row = $this->array_flatten( $result_row );
+				$text = '{{' . $wgMendeleyTemplate . "\n";
+				foreach ( $wgMendeleyTemplateFields as $property => $field ) {
+					if ( strpos( $field, '@' ) === 0 ) {
+						$field = str_replace( '@', '', $field );
+						// special case for authors
+						if ( $property === 'authors' ) {
+							$text .= '|' . $field . '=' .
+									 implode( ',', array_map( function ( $author ) {
+										 return implode( ' ', $author );
+									 }, $row['authors'] ) ) . "\n";
+						} else {
+							$text .= '|' . $field . '=' .
+									 implode( $wgMendeleyTemplateFieldsMapDelimiter, $row[$property] ) .
+									 "\n";
+						}
+					} else {
+						$text .= '|' . $field . '=' . $row[$property] . "\n";
+					}
+				}
+				$text .= '}}';
+
+				$pagename = $result_row['id'];
+
+				// Replace tokens in page formula
+				if ( $wgMendeleyPageFormula ) {
+					$keys = array_map( function ( $key ) {
+						return '<' . $key . '>';
+					}, array_keys( $row ) );
+					$replacements = array_map( function ( $r ) {
+						// Pick only first item from array-values
+						return is_array( $r ) ? $r[0] : $r;
+					}, array_values( $row ) );
+					$pagename = str_ireplace( $keys, $replacements, $wgMendeleyPageFormula );
+				}
+
+				//die();
+
+				$title = Title::newFromText( $pagename );
+				$wikiPage = new WikiPage( $title );
+				$content = ContentHandler::makeContent( $text, $title );
+				$wikiPage->doEditContent( $content, "Importing document found in group" );
+				$pagesLinks[] = $title;
+				$pages ++;
+			}
+			$nextLink = $this->getPaginationLink( $responseHeaders );
+			if ( $nextLink ) {
+				$result = $this->httpRequest( $nextLink, '', array(), $responseHeaders );
+			} else {
+				break;
+			}
+		}
+
+		return $pagesLinks;
+	}
+
+	private function getPaginationLink( array $responseHeaders, $rel = 'next' ) {
+		foreach ( $responseHeaders as $value ) {
+			if ( strncmp( $value, 'Link:', 5 ) === 0 ) {
+				if ( preg_match( '/Link: <([^>]*)>.*rel="([^"]*)"/', $value, $matches ) ) {
+					if ( $matches[2] === $rel ) {
+						return $matches[1];
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Flattens the multi-dimensional array, folds the prop names recursively to a/b/c..
+	 *
+	 * @param $array
+	 * @param string $prefix
+	 *
+	 * @return array|false
+	 */
+	private function array_flatten( $array, $prefix = '' ) {
+		if ( !is_array( $array ) ) {
+			return false;
+		}
+		$result = array();
+		foreach ( $array as $key => $value ) {
+			if ( is_array( $value ) && $this->is_assoc( $value ) ) {
+				$result = array_merge( $result, $this->array_flatten( $value, $key ) );
+			} else {
+				$result = array_merge( $result, array(
+					( $prefix ? $prefix . '/' : '' ) . $key => $value
+				) );
+			}
+		}
+		return $result;
+	}
+
+	/**
+	 * Tests if the array is an associative array
+	 *
+	 * @param array $arr
+	 *
+	 * @return bool
+	 */
+	private function is_assoc( array $arr ) {
+		if ( array() === $arr ) {
+			return false;
+		}
+		return array_keys( $arr ) !== range( 0, count( $arr ) - 1 );
+	}
+
+	public function getAccessToken() {
+		global $wgMendeleyConsumerKey, $wgMendeleyConsumerSecret, $wgMendeleyToken;
+		// test against $wgMendeleyToken to ensure we want to use the auth code flow
+		if ( !empty($wgMendeleyToken) ) {
+			return $this->getToken( 'access' );
+		}
+		$result = $this->httpRequest( "https://api.mendeley.com/oauth/token", "grant_type=client_credentials&scope=all&client_id=$wgMendeleyConsumerKey&client_secret=$wgMendeleyConsumerSecret" );
+		return json_decode( $result )->access_token;
+	}
+
+	/**
+	 * Refreshes access token and accuires new refresh token
+	 * @return array|false
+	 */
+	public function refreshAccessToken() {
+		global $wgMendeleyRefreshToken, $wgMendeleyRedirectUrl,
+			   $wgMendeleyConsumerKey, $wgMendeleyConsumerSecret;
+
+		// check for refresh token setting presence to ensure it was initially set
+		if ( !$wgMendeleyRefreshToken || !$wgMendeleyRedirectUrl ) {
+			return false;
+		}
+
+		$result = $this->httpRequest(
+			"https://api.mendeley.com/oauth/token",
+			"grant_type=refresh_token&refresh_token="
+			. $this->getToken( 'refresh' )
+			. '&client_id='
+			. $wgMendeleyConsumerKey
+			. '&client_secret=' . $wgMendeleyConsumerSecret
+		);
+		$result = json_decode( $result );
+		if ( !$result || isset( $result->message ) ) {
+			throw new Exception("Unable to refresh access token! " . $result->message );
+		}
+
+		$this->setToken( $result->access_token, 'access' );
+		$this->setToken( $result->refresh_token, 'refresh' );
+
+		return true;
+	}
+
+	public function getToken( $token = 'access' ) {
+		global $wgMendeleyRefreshToken, $wgMendeleyToken;
+
+		$cache = wfGetCache( CACHE_ANYTHING );
+		$key = wfMemcKey( 'mendeley_token_' . $token );
+		$keyTs = wfMemcKey( 'mendeley_token_ts_' . $token );
+		$ts = $cache->get( $keyTs );
+		$result = $cache->get( $key );
+		if( $result ) {
+			if( $ts && time() - $ts >= 3600 ) {
+				$this->refreshAccessToken();
+				return $this->getToken( $token );
+			}
+			return $result;
+		}
+		$token = $token == 'access' ? $wgMendeleyToken : $wgMendeleyRefreshToken;
+		$cache->set( $key, $token );
+		// We don't know initial token TS so not using setToken
+		return $token;
+	}
+
+	public function setToken( $value, $token = 'access' ) {
+		$cache = wfGetCache( CACHE_ANYTHING );
+		$key = wfMemcKey( 'mendeley_token_' . $token );
+		$keyTs = wfMemcKey( 'mendeley_token_ts_' . $token );
+		$cache->set( $key, $value );
+		$cache->set( $keyTs, time() );
+	}
+
+	public function httpRequest($url, $post = "", $headers = array(), &$responseHeaders = array() ) {
+		try {
+			$ch = curl_init();
+			//Change the user agent below suitably
+			curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.9) Gecko/20071025 Firefox/2.0.0.9');
+			curl_setopt($ch, CURLOPT_URL, ($url));
+			curl_setopt($ch, CURLOPT_ENCODING, "UTF-8");
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+			curl_setopt($ch, CURLOPT_COOKIESESSION, false);
+			curl_setopt($ch, CURLOPT_TIMEOUT, 20);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+			curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+			#curl_setopt($ch, CURLOPT_VERBOSE, 1);
+			curl_setopt($ch, CURLOPT_HEADER, 1);
+
+			if (!empty($post)) {
+				curl_setopt($ch, CURLOPT_POSTFIELDS, $post);
+				curl_setopt($ch, CURLOPT_POST, 1);
+			}
+			if (!empty($headers)) {
+				curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+			}
+			$response = curl_exec($ch);
+
+			if (!$response) {
+				throw new Exception("Error getting data from server: " . curl_error($ch));
+			}
+			$header_size = curl_getinfo( $ch, CURLINFO_HEADER_SIZE );
+			$responseHeaders = explode( "\r\n", substr( $response, 0, $header_size ) );
+			$body = substr( $response, $header_size );
+
+			curl_close($ch);
+		}
+		catch (Exception $e) {
+			echo 'Caught exception: ', $e->getMessage(), "\n";
+			return null;
+		}
+		return $body;
+	}
+
+}

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -110,12 +110,20 @@ class Mendeley {
 					$keys = array_map( function ( $key ) {
 						return '<' . $key . '>';
 					}, array_keys( $row ) );
-					$replacements = array_map( function ( $r ) {
-						// Pick only first item from array-values
-						$t = is_array( $r ) ? $r[0] : $r;
-						// deep arrays
-						$t = is_array( $t ) ? $t[0] : $t;
-						return $t;
+					$replacements = array_map( function ( $r ) use ( $wgMendeleyTemplateFieldsMapDelimiter ) {
+						if ( is_array( $r ) ) {
+							if( !count( $r) ) {
+								return '';
+							}
+							if ( is_array( $r[0] ) ) {
+								if( !count( $r[0] ) ) {
+									return '';
+								}
+								return implode( ' ', $r[0] );
+							}
+							return $r[0];
+						}
+						return $r;
 					}, array_values( $row ) );
 					$pagename = str_ireplace( $keys, $replacements, $wgMendeleyPageFormula );
 				}

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -106,10 +106,6 @@ class Mendeley {
 							// append different properties to the same field
 							$fieldName = substr( $field, 0, strpos( $field, '[' ) );
 							$fieldName = str_replace( '+', '', $fieldName );
-//							if ( !isset($appendProps[$field]) ) {
-//								$appendProps[$field] = [];
-//							}
-//							$appendProps[$field][] = $row[$property];
 							$appendProps[$fieldName] = $field;
 						} else {
 							$text .= '|' . $field . '=' . $row[$property] . "\n";
@@ -121,11 +117,28 @@ class Mendeley {
 							$pattern = substr( $v, strpos( $v, '[' ) + 1 );
 							$pattern = substr( $pattern, 0,strpos( $pattern, ']' ) );
 							$value = preg_replace_callback( '/\<([a-z]+)\>/', function( $m ) use ( $row ) {
-								return (isset($row[$m[1]])) ? $row[$m[1]] : '';
+								if ( isset($row[$m[1]]) ) {
+									return $row[$m[1]];
+								}
+								return '';
 							}, $pattern );
 							$text .= '|' . $k . '=' . $value . "\n";
 						}
 					}
+
+					// TODO: fixme
+					$dateprop = '';
+					if( isset( $row['year'] ) && !empty( $row['year'] ) ) {
+						$dateprop .= $row['year'];
+						if( isset( $row['month']) && !empty( $row['month'] ) ) {
+							$dateprop .= '-' . $row['month'];
+							if( isset( $row['day']) && !empty( $row['day'] ) ) {
+								$dateprop .= '-' . $row['day'];
+							}
+						}
+					}
+
+					$text .= '|Date=' . $dateprop . "\n";
 
 					$text .= '}}';
 

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -105,10 +105,11 @@ class Mendeley {
 						} elseif ( strpos( $field, '+' ) === 0 ) {
 							// append different properties to the same field
 							$field = str_replace( '+', '', $field );
-							if ( !isset($appendProps[$field]) ) {
-								$appendProps[$field] = [];
-							}
-							$appendProps[$field][] = $row[$property];
+//							if ( !isset($appendProps[$field]) ) {
+//								$appendProps[$field] = [];
+//							}
+//							$appendProps[$field][] = $row[$property];
+							$appendProps[] = $field;
 						} else {
 							$text .= '|' . $field . '=' . $row[$property] . "\n";
 						}
@@ -116,7 +117,12 @@ class Mendeley {
 
 					if ( count( $appendProps ) ) {
 						foreach ( $appendProps as $k => $v ) {
-							$text .= '|' . $k . '=' . implode( $wgMendeleyAppendFieldValuesDelimiter, $v) . "\n";
+							$pattern = substr( $v, strpos( $v, '[' ) + 1 );
+							$pattern = substr( $pattern, 0,strpos( $pattern, ']' ) );
+							$value = preg_replace_callback( '/\<([a-z]+)\>/', function( $m ) use ( $row ) {
+								return $row[$m[1]];
+							}, $pattern );
+							$text .= '|' . $k . '=' . $value . "\n";
 						}
 					}
 

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -25,7 +25,8 @@ class Mendeley {
 		global $wgMendeleyTemplate,
 			   $wgMendeleyTemplateFields,
 			   $wgMendeleyTemplateFieldsMapDelimiter,
-			   $wgMendeleyPageFormula;
+			   $wgMendeleyPageFormula,
+			   $wgMendeleyFieldValuesDelimiter;
 
 		$pages = 0;
 		$pagesLinks = [];
@@ -86,8 +87,8 @@ class Mendeley {
 							if ( is_array( $row[$property] ) ) {
 								if ( count( $row[$property] ) && is_array( $row[$property][0] ) ) {
 									$text .= '|' . $field . '=' .
-											 implode( $wgMendeleyTemplateFieldsMapDelimiter, array_map( function ( $item ) {
-												 return implode( ' ', $item );
+											 implode( $wgMendeleyTemplateFieldsMapDelimiter, array_map( function ( $item ) use ( $wgMendeleyFieldValuesDelimiter ) {
+												 return implode( $wgMendeleyFieldValuesDelimiter, $item );
 											 }, $row[$property] ) ) . "\n";
 								} else {
 									$text .= '|' . $field . '=' .

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -27,7 +27,8 @@ class Mendeley {
 			   $wgMendeleyTemplateFieldsMapDelimiter,
 			   $wgMendeleyPageFormula,
 			   $wgMendeleyFieldValuesDelimiter,
-			   $wgMendeleyAppendFieldValuesDelimiter;
+			   $wgMendeleyAppendFieldValuesDelimiter,
+			   $wgMendeleyReplaceUnderscores;
 
 		$pages = 0;
 		$pagesLinks = [];
@@ -90,12 +91,13 @@ class Mendeley {
 							if ( is_array( $row[$property] ) ) {
 								if ( count( $row[$property] ) && is_array( $row[$property][0] ) ) {
 									$text .= '|' . $field . '=' .
+											 $this->processValue(
 											 implode( $wgMendeleyTemplateFieldsMapDelimiter, array_map( function ( $item ) use ( $wgMendeleyFieldValuesDelimiter ) {
 												 return implode( $wgMendeleyFieldValuesDelimiter, $item );
-											 }, $row[$property] ) ) . "\n";
+											 }, $row[$property] ) ) ) . "\n";
 								} else {
 									$text .= '|' . $field . '=' .
-											 implode( $wgMendeleyTemplateFieldsMapDelimiter, $row[$property] ) .
+											 $this->processValue( implode( $wgMendeleyTemplateFieldsMapDelimiter, $row[$property] ) ) .
 											 "\n";
 								}
 							} else {
@@ -108,7 +110,7 @@ class Mendeley {
 							$fieldName = str_replace( '+', '', $fieldName );
 							$appendProps[$fieldName] = $field;
 						} else {
-							$text .= '|' . $field . '=' . $row[$property] . "\n";
+							$text .= '|' . $field . '=' . $this->processValue( $row[$property] ) . "\n";
 						}
 					}
 
@@ -122,7 +124,7 @@ class Mendeley {
 								}
 								return '';
 							}, $pattern );
-							$text .= '|' . $k . '=' . $value . "\n";
+							$text .= '|' . $k . '=' . $this->processValue( $value ) . "\n";
 						}
 					}
 
@@ -167,8 +169,6 @@ class Mendeley {
 						$pagename = str_ireplace( $keys, $replacements, $wgMendeleyPageFormula );
 					}
 
-					//die();
-
 					$title = Title::newFromText( $pagename );
 					$wikiPage = new WikiPage( $title );
 					$content = ContentHandler::makeContent( $text, $title );
@@ -199,6 +199,14 @@ class Mendeley {
 			}
 		}
 		return null;
+	}
+
+	private function processValue( $value ) {
+		global $wgMendeleyReplaceUnderscores;
+		if ( $wgMendeleyReplaceUnderscores ) {
+			$value = str_replace( '_', ' ', $value );
+		}
+		return $value;
 	}
 
 	/**

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -104,12 +104,13 @@ class Mendeley {
 							}
 						} elseif ( strpos( $field, '+' ) === 0 ) {
 							// append different properties to the same field
-							$field = str_replace( '+', '', $field );
+							$fieldName = substr( $field, 0, strpos( $field, '[' ) );
+							$fieldName = str_replace( '+', '', $fieldName );
 //							if ( !isset($appendProps[$field]) ) {
 //								$appendProps[$field] = [];
 //							}
 //							$appendProps[$field][] = $row[$property];
-							$appendProps[] = $field;
+							$appendProps[$fieldName] = $field;
 						} else {
 							$text .= '|' . $field . '=' . $row[$property] . "\n";
 						}

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -63,6 +63,11 @@ class Mendeley {
 			$result = json_decode( $result, true );
 		}
 
+		// Fail after first refresh try or if token is not refreshable
+		if ( isset( $result['errorId'] ) ) {
+			throw new Exception($result['message']);
+		}
+
 		while ( true ) {
 			foreach ( $result as $result_row ) {
 

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -63,7 +63,7 @@ class Mendeley {
 				"?access_token=$access_token" .
 				"&group_id=$group_id" .
 				"&view=all" .
-				"&limit=500",
+				"&limit=$wgMendeleyImportPageLimit",
 				'',
 				array(),
 				$responseHeaders

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -204,7 +204,7 @@ class Mendeley {
 		return preg_replace_callback(
 			"/\{\{(([^\{\}]*|(?R))*)\}\}/",
 			function( $matches ) use ( $wgMendeleyTemplate, $replacement ) {
-				if ( strpos($matches[0], "{{".$wgMendeleyTemplate) === 0 ) {
+				if ( strpos($matches[0], "{{".$wgMendeleyTemplate."\n") === 0 ) {
 					return $replacement;
 				}
 				return $matches[0];

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -120,7 +120,7 @@ class Mendeley {
 							$pattern = substr( $v, strpos( $v, '[' ) + 1 );
 							$pattern = substr( $pattern, 0,strpos( $pattern, ']' ) );
 							$value = preg_replace_callback( '/\<([a-z]+)\>/', function( $m ) use ( $row ) {
-								return $row[$m[1]];
+								return (isset($row[$m[1]])) ? $row[$m[1]] : '';
 							}, $pattern );
 							$text .= '|' . $k . '=' . $value . "\n";
 						}

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -74,6 +74,10 @@ class Mendeley {
 				$row = $this->array_flatten( $result_row );
 				$text = '{{' . $wgMendeleyTemplate . "\n";
 				foreach ( $wgMendeleyTemplateFields as $property => $field ) {
+					if ( !isset($row[$property]) ) {
+						wfDebugLog( 'Mendeley', 'field '. $property . ' not found!' );
+						continue;
+					}
 					if ( strpos( $field, '@' ) === 0 ) {
 						$field = str_replace( '@', '', $field );
 						// special case for authors

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -21,7 +21,7 @@ class Mendeley {
 	 * @throws MWContentSerializationException
 	 * @throws MWException
 	 */
-	public function importGroup( $group_id ) {
+	public function importGroup( $group_id, $actorId = null ) {
 		global $wgMendeleyTemplate,
 			   $wgMendeleyTemplateFields,
 			   $wgMendeleyTemplateFieldsMapDelimiter,
@@ -185,7 +185,13 @@ class Mendeley {
 
 					// Edit target page or push job into queue
 					if ( $wgMendeleyUseJobs ) {
-						$job = new MendeleyImportJob( $title, [ 'text' => $text ] );
+						$job = new MendeleyImportJob( $title,
+							[
+								'text' => $text,
+								'id' => $result_row['id'],
+								'actor_id' => $actorId
+							]
+						);
 						JobQueueGroup::singleton()->push( $job );
 					} else {
 						$content = ContentHandler::makeContent( $text, $title );

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -39,7 +39,7 @@ class Mendeley {
 			"?access_token=$access_token" .
 			"&group_id=$group_id" .
 			"&view=all" .
-			"&limit=50",
+			"&limit=500",
 			'',
 			array(),
 			$responseHeaders
@@ -59,7 +59,7 @@ class Mendeley {
 				"?access_token=$access_token" .
 				"&group_id=$group_id" .
 				"&view=all" .
-				"&limit=50",
+				"&limit=500",
 				'',
 				array(),
 				$responseHeaders

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -27,8 +27,7 @@ class Mendeley {
 			   $wgMendeleyTemplateFieldsMapDelimiter,
 			   $wgMendeleyPageFormula,
 			   $wgMendeleyFieldValuesDelimiter,
-			   $wgMendeleyAppendFieldValuesDelimiter,
-			   $wgMendeleyReplaceUnderscores;
+			   $wgMendeleyAppendFieldValuesDelimiter;
 
 		$pages = 0;
 		$pagesLinks = [];
@@ -92,12 +91,13 @@ class Mendeley {
 								if ( count( $row[$property] ) && is_array( $row[$property][0] ) ) {
 									$text .= '|' . $field . '=' .
 											 $this->processValue(
+												 $property,
 											 implode( $wgMendeleyTemplateFieldsMapDelimiter, array_map( function ( $item ) use ( $wgMendeleyFieldValuesDelimiter ) {
 												 return implode( $wgMendeleyFieldValuesDelimiter, $item );
 											 }, $row[$property] ) ) ) . "\n";
 								} else {
 									$text .= '|' . $field . '=' .
-											 $this->processValue( implode( $wgMendeleyTemplateFieldsMapDelimiter, $row[$property] ) ) .
+											 $this->processValue( $property, implode( $wgMendeleyTemplateFieldsMapDelimiter, $row[$property] ) ) .
 											 "\n";
 								}
 							} else {
@@ -110,7 +110,7 @@ class Mendeley {
 							$fieldName = str_replace( '+', '', $fieldName );
 							$appendProps[$fieldName] = $field;
 						} else {
-							$text .= '|' . $field . '=' . $this->processValue( $row[$property] ) . "\n";
+							$text .= '|' . $field . '=' . $this->processValue( $property, $row[$property] ) . "\n";
 						}
 					}
 
@@ -124,7 +124,7 @@ class Mendeley {
 								}
 								return '';
 							}, $pattern );
-							$text .= '|' . $k . '=' . $this->processValue( $value ) . "\n";
+							$text .= '|' . $k . '=' . $this->processValue( $property, $value ) . "\n";
 						}
 					}
 
@@ -201,9 +201,9 @@ class Mendeley {
 		return null;
 	}
 
-	private function processValue( $value ) {
-		global $wgMendeleyReplaceUnderscores;
-		if ( $wgMendeleyReplaceUnderscores ) {
+	private function processValue( $property, $value ) {
+		global $wgMendeleyReplaceUnderscoresFields;
+		if ( count($wgMendeleyReplaceUnderscoresFields) && in_array($property, $wgMendeleyReplaceUnderscoresFields) ) {
 			$value = str_replace( '_', ' ', $value );
 		}
 		return $value;

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -112,7 +112,10 @@ class Mendeley {
 					}, array_keys( $row ) );
 					$replacements = array_map( function ( $r ) {
 						// Pick only first item from array-values
-						return is_array( $r ) ? $r[0] : $r;
+						$t = is_array( $r ) ? $r[0] : $r;
+						// deep arrays
+						$t = is_array( $t ) ? $t[0] : $t;
+						return $t;
 					}, array_values( $row ) );
 					$pagename = str_ireplace( $keys, $replacements, $wgMendeleyPageFormula );
 				}

--- a/Mendeley.php
+++ b/Mendeley.php
@@ -26,7 +26,8 @@ class Mendeley {
 			   $wgMendeleyTemplateFields,
 			   $wgMendeleyTemplateFieldsMapDelimiter,
 			   $wgMendeleyPageFormula,
-			   $wgMendeleyFieldValuesDelimiter;
+			   $wgMendeleyFieldValuesDelimiter,
+			   $wgMendeleyAppendFieldValuesDelimiter;
 
 		$pages = 0;
 		$pagesLinks = [];
@@ -74,6 +75,8 @@ class Mendeley {
 			while ( true ) {
 				foreach ( $result as $result_row ) {
 
+					$appendProps = [];
+
 					$row = $this->array_flatten( $result_row );
 					$text = '{{' . $wgMendeleyTemplate . "\n";
 					foreach ( $wgMendeleyTemplateFields as $property => $field ) {
@@ -99,10 +102,24 @@ class Mendeley {
 								// fallback to normal processing
 								$text .= '|' . $field . '=' . $row[$property] . "\n";
 							}
+						} elseif ( strpos( $field, '+' ) === 0 ) {
+							// append different properties to the same field
+							$field = str_replace( '+', '', $field );
+							if ( !isset($appendProps[$field]) ) {
+								$appendProps[$field] = [];
+							}
+							$appendProps[$field][] = $row[$property];
 						} else {
 							$text .= '|' . $field . '=' . $row[$property] . "\n";
 						}
 					}
+
+					if ( count( $appendProps ) ) {
+						foreach ( $appendProps as $k => $v ) {
+							$text .= '|' . $k . '=' . implode( $wgMendeleyAppendFieldValuesDelimiter, $v) . "\n";
+						}
+					}
+
 					$text .= '}}';
 
 					$pagename = $result_row['id'];

--- a/MendeleyImportJob.php
+++ b/MendeleyImportJob.php
@@ -20,7 +20,13 @@ class MendeleyImportJob extends Job {
 	private function editPage() {
 		$wikiPage = new WikiPage( $this->title );
 		$content = ContentHandler::makeContent( $this->params[ 'text' ], $this->title );
-		return $wikiPage->doEditContent( $content, "Importing document found in group (job)" );
+		return $wikiPage->doEditContent(
+			$content,
+			"Importing document found in group (job)",
+			0,
+			false,
+			$this->params['actor_id'] ? User::newFromId( $this->params['actor_id'] ) : null
+		);
 	}
 
 }

--- a/MendeleyImportJob.php
+++ b/MendeleyImportJob.php
@@ -1,0 +1,26 @@
+<?php
+
+class MendeleyImportJob extends Job {
+
+	public function __construct( $title, $params = null ) {
+		parent::__construct( 'MendeleyImportJob', $title, $params );
+		$this->removeDuplicates = true;
+	}
+
+	public function run() {
+		$status = $this->editPage();
+		if ( !$status->isOK() ) {
+			$this->setLastError( $status->getMessage() );
+			return false;
+		}
+
+		return true;
+	}
+
+	private function editPage() {
+		$wikiPage = new WikiPage( $this->title );
+		$content = ContentHandler::makeContent( $this->params[ 'text' ], $this->title );
+		return $wikiPage->doEditContent( $content, "Importing document found in group (job)" );
+	}
+
+}

--- a/PFMendeleyAutocompleteAPI.php
+++ b/PFMendeleyAutocompleteAPI.php
@@ -15,12 +15,14 @@ class PFMendeleyAutocompleteAPI extends ApiBase {
 	public function execute() {
 		$term = urlencode( $this->getMain()->getVal('term') );
 
-		$access_token = MendeleyHooks::getAccessToken();
+		$mendeley = Mendeley::getInstance();
 
-		$result = MendeleyHooks::httpRequest( "https://api.mendeley.com/search/catalog?query==$term&access_token=$access_token&view=all&limit=20" );
+		$access_token = $mendeley->getAccessToken();
+
+		$result = $mendeley->httpRequest( "https://api.mendeley.com/search/catalog?query==$term&access_token=$access_token&view=all&limit=20" );
 		$result = json_decode( $result, true );
 		if ( empty( $result ) ) {
-			$result = MendeleyHooks::httpRequest( "https://api.mendeley.com/catalog?doi=". $term ."&access_token=$access_token&view=all" );
+			$result = $mendeley->httpRequest( "https://api.mendeley.com/catalog?doi=". $term ."&access_token=$access_token&view=all" );
 			$result = json_decode( $result, true );
 		}
 

--- a/PFMendeleyInputDOI.php
+++ b/PFMendeleyInputDOI.php
@@ -35,7 +35,16 @@ class PFMendeleyInputDOI extends PFFormInput {
 			$spanClass .= ' mandatoryFieldSpan';
 		}
 
-		return Html::rawElement( 'span', array( 'class' => $spanClass ), Html::input( $input_name, $cur_value, 'text', $doiInputAttrs ) );
+		return Html::rawElement(
+			'span',
+			array( 'class' => $spanClass ),
+			Html::input(
+				$input_name,
+				$cur_value,
+				'text',
+				$doiInputAttrs
+			)
+		);
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,78 @@
 # Mendeley
+
 A MediaWiki Extension to work with the Mendeley API
 
+# Setup 
 
-Please follow the instructions at https://www.mediawiki.org/wiki/Extension:Mendeley
+* Create new application at https://dev.mendeley.com/myapps.html
+* Set `$wgMendeleyConsumerKey` to app `ID` and `MendeleyConsumerSecret` to app `SECRET` values
+* Set `$wgMendeleyRedirectUrl` to the app redirect URL
+
+That's all!
+
+# Setup for private spaces
+
+If you want to be able to fetch data from private groups & resources on Mendeley you'll need to
+do some extra configurations in addition to the above:
+
+* Navigate to https://mendeley-show-me-access-tokens.herokuapp.com/ and login with your Mendeley credentials
+* Set `$wgMendeleyToken` to the `Access token` value
+* Set `$wgMendeleyRefreshToken` to the `Refresh token` value
+
+The authorization code flow token has a lifetime of 1 hour, it'll be automatically renewed as soon as it expires,
+however, you can also use `maintenance/refreshToken.php` to force the token refresh.
+
+**Important:** Memcached or Redis is required for this! Ensure you have one of these installed on your server
+and configured as main cache type, eg:
+
+```
+$wgMemCachedServers = [ '127.0.0.1:11211' ];
+$wgMainCacheType = CACHE_MEMCACHED;
+```
+
+# Usage
+
+Use `mendeley` parser function to fetch Mendeley data:
+```
+{{#mendeley:doi=10.1103/PhysRevA.20.1521|parameter=title}}
+```
+
+Or `Special:MendeleyImport` special page to import groups of documents into your wiki
+
+# Import configuration
+
+By default, the extension will import documents as `Article` template with no fields and
+name imported pages after the documents IDs on the Mendeley DB. This can be altered for your needs:
+
+* `$wgMendeleyTemplate` - name of the template to use for imported pages
+* `$wgMendeleyTemplateFields` - mapping scheme between template and Mendeley fields, see Mendeley fields names at
+https://api.mendeley.com/apidocs/docs#!/documents/getDocuments, the format is `mendeley_field => template_field`
+* `$wgMendeleyPageFormula` - formula for imported pages titles, mendeley fields tokens will be substituted,
+eg: `Reference:<title>` will put imported page into a `Reference` namespace with a `title` field as page name
+
+Example of fields mapping:
+```
+$wgMendeleyTemplateFields = [
+	'type' => 'Type',
+	'title' => 'Title',
+	'abstract' => 'Abstract',
+	'accessed' => 'Accessed',
+	'authors' => '@Authors',
+	'source' => 'Source',
+	'volume' => 'Volume',
+	'websites' => '@Websites',
+	'identifiers/doi' => 'Doi',
+	'keywords' => 'Keywords',
+];
+```
+
+Not that some fields on the Mendeley are lists, use `@` char in front of template field name to split field values,
+list delimiter can be configured via `$wgMendeleyTemplateFieldsMapDelimiter`, it's `;` by default.
+
+You can also import groups via `maintenance/importGroup.php` script:
+
+```
+php maintenance/importGroup.php --group_id XXX
+```
+
+Please see more at https://www.mediawiki.org/wiki/Extension:Mendeley

--- a/SpecialMendeleyImport.php
+++ b/SpecialMendeleyImport.php
@@ -31,8 +31,9 @@ class SpecialMendeleyImport extends SpecialPage {
 			Html::closeElement( 'form' )
 		);
 
-		if ( $request->getVal( "mendeley_group_id" ) ) {
-			$this->handleImport( $request->getVal( "mendeley_group_id" ) );
+		$group_id = $request->getVal( "mendeley_group_id", $par );
+		if ( $group_id ) {
+			$this->handleImport( $group_id );
 		}
 	}
 

--- a/SpecialMendeleyImport.php
+++ b/SpecialMendeleyImport.php
@@ -6,19 +6,6 @@ class SpecialMendeleyImport extends SpecialPage {
 		parent::__construct( 'MendeleyImport', 'mendeleyimport' );
 	}
 
-	private static function getPaginationLink( array $responseHeaders, $rel = 'next' ) {
-		foreach ( $responseHeaders as $value ) {
-			if ( strncmp( $value, 'Link:', 5 ) === 0 ) {
-				if ( preg_match( '/Link: <([^>]*)>.*rel="([^"]*)"/', $value, $matches ) ) {
-					if ( $matches[2] === $rel ) {
-						return $matches[1];
-					}
-				}
-			}
-		}
-		return null;
-	}
-
 	/**
 	 */
 	public function execute( $par ) {
@@ -50,45 +37,18 @@ class SpecialMendeleyImport extends SpecialPage {
 	}
 
 	public function handleImport( $group_id ) {
-		$pages = 0;
-		$access_token = MendeleyHooks::getAccessToken();
-		$responseHeaders = [];
-		$result = MendeleyHooks::httpRequest( "https://api.mendeley.com/documents?access_token=$access_token&group_id=$group_id&view=all&limit=50", '', array(), $responseHeaders );
-		while ( true ) {
-			$result = json_decode( $result, true );
-			foreach( $result as $result_row ) {
-				$text = '
-{{Article
-|Type='. $result_row['type'] .'
-|Title='. $result_row['title'] .'
-|Abstract='. $result_row['abstract'] .'
-|Accessed='. $result_row['accessed'] .'
-|Authors='. implode( ',', array_map( function ( $author ) { return implode( ' ', $author ); }, $result_row['authors'] ) ) .'
-|Source='. $result_row['source'] .'
-|Volume='. $result_row['volume'] .'
-|Websites='. implode( ',', $result_row['websites'] ) .'
-|Doi='. $result_row['identifiers']['doi'] .'
-|Keywords='. implode( ';', $result_row['keywords'] ) .'
-}}';
-				$title = Title::newFromText( $result_row['id'] );
-				$wikiPage = new WikiPage( $title );
-				$content = ContentHandler::makeContent( $text, $title );
-				$wikiPage->doEditContent( $content , "Importing document found in group" );
-				$pages++;
-			}
-			$nextLink = self::getPaginationLink( $responseHeaders );
-			if ( $nextLink ) {
-				$result = MendeleyHooks::httpRequest( $nextLink, '', array(), $responseHeaders );
-			} else {
-				break;
-			}
-		}
-
+		$pages = Mendeley::getInstance()->importGroup( $group_id );
 		$out = $this->getOutput();
-		if ( $pages > 0 ) {
-			$out->addHTML( "Successfully created/updated $pages pages" );
+		if ( count($pages) > 0 ) {
+			$out->addHTML( Html::openElement('ul') );
+			foreach ($pages as $pl) {
+				$out->addHTML( Html::rawElement( 'li', array(), Linker::link($pl) ) );
+			}
+			$out->addHTML( Html::closeElement('ul') );
+			$out->addHTML( "Successfully created/updated ".count($pages)." pages" );
 		} else {
 			$out->addHTML( "Invalid result" );
 		}
 	}
+
 }

--- a/SpecialMendeleyImport.php
+++ b/SpecialMendeleyImport.php
@@ -40,7 +40,7 @@ class SpecialMendeleyImport extends SpecialPage {
 
 	public function handleImport( $group_id ) {
 		global $wgMendeleyUseJobs;
-		$pages = Mendeley::getInstance()->importGroup( $group_id );
+		$pages = Mendeley::getInstance()->importGroup( $group_id, $this->getUser()->getId() );
 		$out = $this->getOutput();
 		if ( count($pages) > 0 ) {
 			$out->addHTML( Html::openElement('ul') );

--- a/SpecialMendeleyImport.php
+++ b/SpecialMendeleyImport.php
@@ -13,6 +13,8 @@ class SpecialMendeleyImport extends SpecialPage {
 		$request = $this->getRequest();
 		$out = $this->getOutput();
 
+		$group_id = $request->getVal( "mendeley_group_id", $par );
+
 		$formOpts = [
 			'id' => 'menedeley_import',
 			'method' => 'post',
@@ -23,7 +25,7 @@ class SpecialMendeleyImport extends SpecialPage {
 		$out->addHTML(
 			Html::openElement( 'form', $formOpts ) . "<br>" .
 			Html::label( "Enter Mendeley Group ID","", array( "for" => "mendeley_group_id" ) ) . "<br>" .
-			Html::element( 'input', array( "id" => "mendeley_group_id", "name" => "mendeley_group_id", "type" => "text" ) ) . "<br><br>"
+			Html::element( 'input', array( "id" => "mendeley_group_id", "name" => "mendeley_group_id", "type" => "text", "value" => $group_id ) ) . "<br><br>"
 		);
 
 		$out->addHTML(
@@ -31,7 +33,6 @@ class SpecialMendeleyImport extends SpecialPage {
 			Html::closeElement( 'form' )
 		);
 
-		$group_id = $request->getVal( "mendeley_group_id", $par );
 		if ( $group_id ) {
 			$this->handleImport( $group_id );
 		}

--- a/SpecialMendeleyImport.php
+++ b/SpecialMendeleyImport.php
@@ -39,6 +39,7 @@ class SpecialMendeleyImport extends SpecialPage {
 	}
 
 	public function handleImport( $group_id ) {
+		global $wgMendeleyUseJobs;
 		$pages = Mendeley::getInstance()->importGroup( $group_id );
 		$out = $this->getOutput();
 		if ( count($pages) > 0 ) {
@@ -47,7 +48,13 @@ class SpecialMendeleyImport extends SpecialPage {
 				$out->addHTML( Html::rawElement( 'li', array(), Linker::link($pl) ) );
 			}
 			$out->addHTML( Html::closeElement('ul') );
-			$out->addHTML( "Successfully created/updated ".count($pages)." pages" );
+			if ( $wgMendeleyUseJobs ) {
+				$out->addHTML( "Successfully scheduled " . count( $pages ) . " pages for import. " .
+							   "Please wait for the jobs to be processed or run runJobs.php maintenance " .
+							   "script by hand." );
+			} else {
+				$out->addHTML( "Successfully created/updated " . count( $pages ) . " pages" );
+			}
 		} else {
 			$out->addHTML( "Invalid result" );
 		}

--- a/extension.json
+++ b/extension.json
@@ -39,7 +39,8 @@
 		"MendeleyPageFormula": null,
 		"MendeleyRedirectUrl": null,
 		"MendeleyFieldValuesDelimiter": " ",
-		"MendeleyAppendFieldValuesDelimiter": "/"
+		"MendeleyAppendFieldValuesDelimiter": "/",
+		"MendeleyReplaceUnderscores": false
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"

--- a/extension.json
+++ b/extension.json
@@ -26,7 +26,8 @@
 		"PFMendeleyInput": "PF_MendeleyInput.php",
 		"PFMendeleyInputDOI": "PFMendeleyInputDOI.php",
 		"PFMendeleyAutocompleteAPI": "PFMendeleyAutocompleteAPI.php",
-		"Mendeley": "Mendeley.php"
+		"Mendeley": "Mendeley.php",
+		"MendeleyImportJob": "MendeleyImportJob.php"
 	},
 	"config": {
 		"MendeleyConsumerKey": null,
@@ -41,7 +42,9 @@
 		"MendeleyFieldValuesDelimiter": " ",
 		"MendeleyAppendFieldValuesDelimiter": "/",
 		"MendeleyReplaceUnderscores": false,
-		"MendeleyOverwriteTemplateOnly": false
+		"MendeleyOverwriteTemplateOnly": false,
+		"MendeleyImportPageLimit": 500,
+		"MendeleyUseJobs": false
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"
@@ -71,6 +74,9 @@
 	"ResourceFileModulePaths": {
 		"localBasePath": "",
 		"remoteExtPath": "Mendeley"
+	},
+	"JobClasses": {
+		"MendeleyImportJob": "MendeleyImportJob"
 	},
 	"manifest_version": 1
 }

--- a/extension.json
+++ b/extension.json
@@ -40,7 +40,8 @@
 		"MendeleyRedirectUrl": null,
 		"MendeleyFieldValuesDelimiter": " ",
 		"MendeleyAppendFieldValuesDelimiter": "/",
-		"MendeleyReplaceUnderscores": false
+		"MendeleyReplaceUnderscores": false,
+		"MendeleyOverwriteTemplateOnly": false
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"

--- a/extension.json
+++ b/extension.json
@@ -38,7 +38,8 @@
 		"MendeleyTemplateFieldsMapDelimiter": ";",
 		"MendeleyPageFormula": null,
 		"MendeleyRedirectUrl": null,
-		"MendeleyFieldValuesDelimiter": " "
+		"MendeleyFieldValuesDelimiter": " ",
+		"MendeleyAppendFieldValuesDelimiter": "/"
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"

--- a/extension.json
+++ b/extension.json
@@ -37,7 +37,8 @@
 		"MendeleyTemplateFields": [],
 		"MendeleyTemplateFieldsMapDelimiter": ";",
 		"MendeleyPageFormula": null,
-		"MendeleyRedirectUrl": null
+		"MendeleyRedirectUrl": null,
+		"MendeleyFieldValuesDelimiter": " "
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Mendeley",
-	"version": "0.1 beta",
+	"version": "0.2 beta",
 	"author": [
 		"Nischay Nahata",
 		"Wikiworks.com"
@@ -25,11 +25,19 @@
 		"MendeleyHooks": "Mendeley.hooks.php",
 		"PFMendeleyInput": "PF_MendeleyInput.php",
 		"PFMendeleyInputDOI": "PFMendeleyInputDOI.php",
-		"PFMendeleyAutocompleteAPI": "PFMendeleyAutocompleteAPI.php"
+		"PFMendeleyAutocompleteAPI": "PFMendeleyAutocompleteAPI.php",
+		"Mendeley": "Mendeley.php"
 	},
 	"config": {
-		"wgMendeleyConsumerKey": null,
-		"wgMendeleyConsumerSecret": null
+		"MendeleyConsumerKey": null,
+		"MendeleyConsumerSecret": null,
+		"MendeleyToken": null,
+		"MendeleyRefreshToken": null,
+		"MendeleyTemplate": "Article",
+		"MendeleyTemplateFields": [],
+		"MendeleyTemplateFieldsMapDelimiter": ";",
+		"MendeleyPageFormula": null,
+		"MendeleyRedirectUrl": null
 	},
 	"ExtensionMessagesFiles": {
 		"MendeleyHooksMagic": "Mendeley.i18n.magic.php"

--- a/maintenance/importGroup.php
+++ b/maintenance/importGroup.php
@@ -18,6 +18,11 @@ class MendeleyImportGroupMaintenance extends Maintenance {
 	}
 
 	public function execute() {
+		global $wgMendeleyUseJobs;
+		// save jobs configuration, we do not want to use jobs in the maintenance script
+		// regardless of the setting
+		$oldGlobal = $wgMendeleyUseJobs;
+		$wgMendeleyUseJobs = false;
 		$this->output('Starting import..');
 		$mendeley = Mendeley::getInstance();
 		$result = $mendeley->importGroup( $this->getOption( 'group_id') );
@@ -25,6 +30,8 @@ class MendeleyImportGroupMaintenance extends Maintenance {
 			$this->output("\nImported '".$page->getFullText()."' -> ".$page->getFullURL());
 		}
 		$this->output('Done!');
+		// restore
+		$wgMendeleyUseJobs = $oldGlobal;
 	}
 }
 

--- a/maintenance/importGroup.php
+++ b/maintenance/importGroup.php
@@ -1,0 +1,32 @@
+<?php
+
+if ( getenv( 'MW_INSTALL_PATH' ) ) {
+	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
+} else {
+	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
+}
+
+/**
+ * @ingroup Maintenance
+ */
+class MendeleyImportGroupMaintenance extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Imports group from Mendeley' );
+		$this->addOption('group_id', 'Group id', true, true, 'g');
+	}
+
+	public function execute() {
+		$this->output('Starting import..');
+		$mendeley = Mendeley::getInstance();
+		$result = $mendeley->importGroup( $this->getOption( 'group_id') );
+		foreach ($result as $page) {
+			$this->output("\nImported '".$page->getFullText()."' -> ".$page->getFullURL());
+		}
+		$this->output('Done!');
+	}
+}
+
+$maintClass = MendeleyImportGroupMaintenance::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/refreshToken.php
+++ b/maintenance/refreshToken.php
@@ -1,0 +1,28 @@
+<?php
+
+if ( getenv( 'MW_INSTALL_PATH' ) ) {
+	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
+} else {
+	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
+}
+
+/**
+ * @ingroup Maintenance
+ */
+class MendeleyRefreshTokenMaintenance extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Refreshes Mendeley token' );
+	}
+
+	public function execute() {
+		$this->output('Starting..');
+		$mendeley = Mendeley::getInstance();
+		$mendeley->refreshAccessToken();
+		$this->output('Done!');
+	}
+}
+
+$maintClass = MendeleyRefreshTokenMaintenance::class;
+require_once RUN_MAINTENANCE_IF_MAIN;

--- a/maintenance/wipeGroup.php
+++ b/maintenance/wipeGroup.php
@@ -41,8 +41,8 @@ class MendeleyWipeGroupMaintenance extends Maintenance {
 					'delete',
 					true
 				);
+				$this->output( "\nWiped " . $page->getFullText() );
 			}
-			$this->output( "\nWiped '" . $page->getFullText() );
 		}
 		$this->output( "\n" );
 		$this->output( 'Done!' );

--- a/maintenance/wipeGroup.php
+++ b/maintenance/wipeGroup.php
@@ -1,0 +1,55 @@
+<?php
+
+if ( getenv( 'MW_INSTALL_PATH' ) ) {
+	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
+} else {
+	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
+}
+
+/**
+ * @ingroup Maintenance
+ */
+class MendeleyWipeGroupMaintenance extends Maintenance {
+
+	public function __construct() {
+		parent::__construct();
+		$this->addDescription( 'Wipes pages that were imported from selected group' );
+		$this->addOption( 'group_id', 'Group id', true, true, 'g' );
+	}
+
+	public function execute() {
+		global $wgMendeleyUseJobs;
+		// save jobs configuration, we do not want to use jobs in the maintenance script
+		// regardless of the setting
+		$oldGlobal = $wgMendeleyUseJobs;
+		$wgMendeleyUseJobs = false;
+		$this->output( 'Starting wiping..' );
+		$mendeley = Mendeley::getInstance();
+		$result = $mendeley->importGroup( $this->getOption( 'group_id' ), null, true );
+		foreach ( $result as $page ) {
+			$wp = WikiPage::factory( $page );
+			if ( $wp->exists() ) {
+				$e = [];
+				$wp->doDeleteArticleReal(
+					'Wiped by maintenance script',
+					false,
+					false,
+					null,
+					$e,
+					null,
+					[],
+					'delete',
+					true
+				);
+			}
+			$this->output( "\nWiped '" . $page->getFullText() );
+		}
+		$this->output( "\n" );
+		$this->output( 'Done!' );
+		// restore
+		$wgMendeleyUseJobs = $oldGlobal;
+	}
+}
+
+$maintClass = MendeleyWipeGroupMaintenance::class;
+require_once RUN_MAINTENANCE_IF_MAIN;


### PR DESCRIPTION
- Adds support for Authorization code flow (to fetch from private groups)
- Automatically refreshes expired tokens (via app codes)
- Import template name and fields mapping can be configured now
- A little bit of refactoring
- Maintenance script `maintenance/importGroup.php --group_id XXX` to import groups
- Optimised API batch calls
- Maintenance script `maintenance/wipeGroup.php --group_id XXX` to wipe import groups